### PR TITLE
memory leak

### DIFF
--- a/WavesSDKCrypto/Vendors/Curve25519/Sources/ed25519/additions/curve_sigs.c
+++ b/WavesSDKCrypto/Vendors/Curve25519/Sources/ed25519/additions/curve_sigs.c
@@ -63,7 +63,7 @@ int curve25519_sign(unsigned char* signature_out,
    signature_out[63] &= 0x7F; /* bit should be zero already, but just in case */
    signature_out[63] |= sign_bit;
 
-   //free(sigbuf);
+   free(sigbuf);
    return 0;
 }
 


### PR DESCRIPTION
My application had a memory leak and  I traced it down to this method. sigbuf causes the memory leak. free command commented, I don't know why but shouldn't it be freed on prior to return?