### PR TITLE
Update TransactionSignatureV1.swift

### DIFF
--- a/WavesSDK/Sources/Signature/TransactionSignatureV1.swift
+++ b/WavesSDK/Sources/Signature/TransactionSignatureV1.swift
@@ -409,12 +409,12 @@ private extension TransactionSignatureV1.Structure.InvokeScript {
             
             let assetId = assetIdTrue.isEmpty ? [UInt8(0)] : ([UInt8(1)] + (WavesCrypto.shared.base58decode(input: assetIdTrue) ?? []))
             
-            bytes += amount
-            bytes += assetId
+            let paymentByte = amount + assetId
+            bytes += paymentByte.arrayWithSize()
         }
         
         if bytes.count > 0 {
-            bytes = toByteArray(Int16(self.payment.count)) + bytes.arrayWithSize()
+            bytes = toByteArray(Int16(self.payment.count)) + bytes
         } else {
             bytes = toByteArray(Int16(self.payment.count))
         }


### PR DESCRIPTION
More than one payment fails to validate when arrayWithSize() included after all paymentItems added to bytes array.

If there are two items in payment array arrayWithSize() gives wrong size

Updated version calculates two and more items as following;
[ <array_size><item_01_size><item01><item_02_size><item02>]
Passes proof validation.

Current version calculates two items as following; 
[<array_size><item_01_size + item_02_size><item_01> <item02> ]
Fails proof validation